### PR TITLE
Fix reference error when used in browsers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,4 +201,4 @@
   } else {
     global.EventTracker = EventTracker;
   }
-}(global || this);
+}(typeof global !== 'undefined' ? global : this);


### PR DESCRIPTION
If `global` is not defined (i.e. if we're in a browser instead of node), `global || this` throws a `ReferenceError`.

:eyeglasses: @ajacksified 
