### PR TITLE
Fix bug if performance.now is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,13 @@
   // Stub out `now` so we can use a more precise number in uuid generation, if
   // available.
   function now() {
-    return global.performance ? global.performance.now() : (new Date()).getTime();
+    if (global.performance && global.performance.now instanceof Function) {
+      return global.performance.now();
+    } else if (Date.now instanceof Function) {
+      return Date.now();
+    } else {
+      return (new Date()).getTime();
+    }
   }
 
   // Pulled from elsewhere

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@
   // Stub out `now` so we can use a more precise number in uuid generation, if
   // available.
   function now() {
-    if (global.performance && global.performance.now instanceof Function) {
+    if (global.performance && typeof global.performance.now === 'function') {
       return global.performance.now();
-    } else if (Date.now instanceof Function) {
+    } else if (typeof Date.now === 'function') {
       return Date.now();
     } else {
       return (new Date()).getTime();


### PR DESCRIPTION
Some browsers apparently define `performance` but not `performance.now`, leading to an error getting thrown here.

This adds a more explicit check for `performance.now`, and also adds a check for `Date.now` support, since that's a little nicer than `new Date().getTime()`.

:eyeglasses: @ajacksified @florenceyeun 
