### PR TITLE
Add optional callback to #send

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ tracker.track('mod_events', 'ban', {
 // send immediately rather than buffering. Without calling `send()`, the event
 // will be sent after buffer timeout (100ms) or buffer max length (40) is
 // reached. `send` flushes the current buffer of events and resets the timer.
-tracker.send();
+// send optionally takes a callback.
+tracker.send(callback);
 ```
 
 See [this wiki page](https://reddit.atlassian.net/wiki/pages/viewpage.action?pageId=19267594)

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@
    *
    * clientKey: the name of the secret key you must have to send events, like 'Test1'
    * clientSecret: the secret key you must have to send events, like 'ab42sdfsafsc'
-   * postData: a function with the object arg ({url, data, query, headers}).
+   * postData: a function with the object arg ({url, data, query, headers, done}).
    *   You'll supply a function that wraps jQuery.ajax or superagent.
    * eventsUrl: the url of the events endpoint, like 'https://stats.redditmedia.com/events'
    * appName: the name of your client app, like 'Alien Blue'
@@ -104,8 +104,9 @@
   /*
    * Immediately flush the buffer. Called internally as well during buffer
    * timeout.
+   * done: optional callback to fire on complete.
    */
-  EventTracker.prototype.send = function send() {
+  EventTracker.prototype.send = function send(done) {
     if (this.buffer.length) {
       var data = JSON.stringify(this.buffer);
 
@@ -122,7 +123,8 @@
         query: {
           key: this.clientKey,
           mac: hash,
-        }
+        },
+        done: done || function() {},
       });
 
       this.buffer = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-tracker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "send events to the /events endpoint easily",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
:eyeglasses: @ajacksified 

This is useful for forcing a flush on a page that needs to redirect immediately after.  Ajax requests may or may not complete otherwise.
