### PR TITLE
Dont build client context on server

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@
     data.payload.app_name = this.clientName;
     data.payload.utc_offset = now.getTimezoneOffset() / -60;
 
-    if (this.appendClientContext) {
+    if (this.appendClientContext && process.env.ENV !== 'server') {
       var clientContext = this._buildClientContext();
       for (var c in clientContext) {
         data.payload[c] = clientContext[c];


### PR DESCRIPTION
For some reason the event tracker was trying to build the clientContext on the server even when the appendClientContext option is passed in as false. Doing so will always result in the error `navigator is undefined` so we prevent this from happening by checking the process environment.